### PR TITLE
🛠️ Modification to bin cobalt outputs and add purity forcing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           nf-test test tests/main.runamber.nf.test
           nf-test test tests/main.runcobalt.nf.test
+          nf-test test tests/main.bincobalt.nf.test
           nf-test test tests/main.runpurple.nf.test
       - name: Run pipeline end-to-end test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           sudo mv nf-test /usr/local/bin/
       - name: Pull Docker image and cache
         run: |
-          docker pull papaemmelab/purple:v0.1.0
+          docker pull papaemmelab/purple:v0.1.1
       - name: Run unit tests of each process for Amber, Cobalt, Purple
         run: |
           nf-test test tests/main.runamber.nf.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,15 @@
 FROM papaemmelab/docker-hmftools:v1.0.0
 
+# Clean up to free space
+RUN apt-get clean
+
 # Install dependencies
-RUN apt-get update && apt-get install -y tar curl python3
+RUN apt-get update && apt-get install -y \
+    tar \
+    curl \
+    python3 \
+    python3-pip \
+    python3-venv
 
 # Install Google Cloud SDK
 RUN curl -sSL https://sdk.cloud.google.com | bash
@@ -19,6 +27,10 @@ RUN \
     gsutil cp gs://hmf-public/HMFtools-Resources/dna_pipeline/v${HMFTOOLS_VERSION_UNDERSCORE}/${GENOME_VERSION}/${REF_DIR}.tar.gz /data/ && \
     tar -xzf /data/${REF_DIR}.tar.gz -C /data && \
     rm /data/${REF_DIR}.tar.gz
+
+# Link python3 to python and install packages
+RUN ln -s /usr/bin/python3 /usr/bin/python && \
+    pip install --no-cache-dir numpy pandas
 
 COPY . /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ More information on their [docs](https://github.com/hartwigmedical/hmftools/blob
 sh tests/run_test.sh
 ```
 
+To check tests and update snapshots run:
+```bash
+nf-test test --update-snapshot
+```
+
 ### Docker
 
 [Purple Docker image](https://hub.docker.com/r/papaemmelab/purple) was built for several platforms using [docker buildx](https://docs.docker.com/buildx/working-with-buildx/).

--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,5 @@
 params.cores = 4
+params.memory = '32 GB'
 
 // Params Defaults in juno
 params.refGenome = "/work/isabl/ref/homo_sapiens/GRCh37d5/gr37.fasta"
@@ -23,6 +24,7 @@ log.info """\
     tumorBam     : ${params.tumorBam}
     outdir       : ${params.outdir}
     cores        : ${params.cores}
+    memory       : ${params.memory}
     binProbes    : ${params.binProbes}
     binLogR      : ${params.binLogR}
     minPurity    : ${params.minPurity}
@@ -40,7 +42,7 @@ process runAmber {
     tag "AMBER on ${params.tumor}"
     publishDir "${params.outdir}/amber", mode: 'copy'
     cpus params.cores
-    memory '32 GB'
+    memory params.memory
     time '1h'
 
     input:
@@ -77,7 +79,7 @@ process runCobalt {
     tag "COBALT on ${params.tumor}"
     publishDir "${params.outdir}/cobalt", mode: 'copy'
     cpus params.cores
-    memory '32 GB'
+    memory params.memory
     time '1h'
 
     input:
@@ -111,7 +113,7 @@ process binCobalt {
     tag "COBALT BIN on ${params.tumor}"
     publishDir "${params.outdir}/cobalt/binned_${params.binProbes}_probes_${params.binLogR}_LogR", mode: 'copy'
     cpus params.cores
-    memory '32 GB'
+    memory params.memory
     time '1h'
 
     input:
@@ -185,7 +187,7 @@ process runPurple {
     tag "PURPLE on ${params.tumor}"
     publishDir "${params.outdir}/purple/purple_${params.minPurity}_${params.maxPurity}", mode: 'copy'
     cpus params.cores
-    memory '32 GB'
+    memory params.memory
     time '1h'
 
     input:

--- a/main.nf
+++ b/main.nf
@@ -1,4 +1,4 @@
-params.cores = 4
+params.cores = 1 
 params.memory = '4 GB'
 
 // Params Defaults in juno
@@ -140,9 +140,9 @@ process binCobalt {
     chrom_arm = None
     last_idx = None
     for idx, seg in cobalt_ratio_pcf.iterrows():
-        if chrom_arm != '_'.join(seg[['chrom','arm']]):
-            chrom_arm = '_'.join(seg[['chrom','arm']])
-            cobalt_ratio_pcf_probes = cobalt_ratio_pcf_probes.append(seg, ignore_index=True)
+        if chrom_arm != '_'.join(seg[['chrom','arm']].astype(str)):
+            chrom_arm = '_'.join(seg[['chrom','arm']].astype(str))
+            cobalt_ratio_pcf_probes = pd.concat([cobalt_ratio_pcf_probes, seg.to_frame().T], ignore_index=True)
             last_idx = cobalt_ratio_pcf_probes.index[-1]
             continue
         if (
@@ -156,7 +156,7 @@ process binCobalt {
             cobalt_ratio_pcf_probes.loc[last_idx, 'n.probes'] += seg['n.probes']
             cobalt_ratio_pcf_probes.loc[last_idx, 'end.pos'] = seg['end.pos']
         else:
-            cobalt_ratio_pcf_probes = cobalt_ratio_pcf_probes.append(seg, ignore_index=True)
+            cobalt_ratio_pcf_probes = pd.concat([cobalt_ratio_pcf_probes, seg.to_frame().T], ignore_index=True)
             last_idx = cobalt_ratio_pcf_probes.index[-1]
 
     # Then bin by logR mean
@@ -164,9 +164,9 @@ process binCobalt {
     cobalt_ratio_pcf_probes_logR = pd.DataFrame(columns=cobalt_ratio_pcf_probes.columns)
     chrom_arm = None
     for idx, seg in cobalt_ratio_pcf_probes.iterrows():
-        if chrom_arm != '_'.join(seg[['chrom','arm']]):
-            chrom_arm = '_'.join(seg[['chrom','arm']])
-            cobalt_ratio_pcf_probes_logR = cobalt_ratio_pcf_probes_logR.append(seg, ignore_index=True)
+        if chrom_arm != '_'.join(seg[['chrom','arm']].astype(str)):
+            chrom_arm = '_'.join(seg[['chrom','arm']].astype(str))
+            cobalt_ratio_pcf_probes_logR = pd.concat([cobalt_ratio_pcf_probes_logR, seg.to_frame().T], ignore_index=True)
             last_idx = cobalt_ratio_pcf_probes_logR.index[-1]
             continue
         if abs(cobalt_ratio_pcf_probes.loc[last_idx, 'mean'] - seg['mean']) <= ${binLogR}:
@@ -176,7 +176,7 @@ process binCobalt {
             cobalt_ratio_pcf_probes_logR.loc[last_idx, 'n.probes'] += seg['n.probes']
             cobalt_ratio_pcf_probes_logR.loc[last_idx, 'end.pos'] = seg['end.pos']
         else:
-            cobalt_ratio_pcf_probes_logR = cobalt_ratio_pcf_probes_logR.append(seg, ignore_index=True)
+            cobalt_ratio_pcf_probes_logR = pd.concat([cobalt_ratio_pcf_probes_logR, seg.to_frame().T], ignore_index=True)
             last_idx = cobalt_ratio_pcf_probes_logR.index[-1]
  
     cobalt_ratio_pcf_probes_logR.to_csv("${tumor}.cobalt.ratio.pcf", sep='\\t', index=False)

--- a/main.nf
+++ b/main.nf
@@ -1,5 +1,5 @@
 params.cores = 4
-params.memory = '32 GB'
+params.memory = '4 GB'
 
 // Params Defaults in juno
 params.refGenome = "/work/isabl/ref/homo_sapiens/GRCh37d5/gr37.fasta"
@@ -228,6 +228,8 @@ process runPurple {
         -circos ${params.circos} \
         -min_purity ${params.minPurity} \
         -max_purity ${params.maxPurity}
+
+    rsync -a --no-links \$PWD/ ${params.outdir}/purple/
     """.stripIndent()
 }
 

--- a/main.nf
+++ b/main.nf
@@ -180,7 +180,7 @@ process binCobalt {
             last_idx = cobalt_ratio_pcf_probes_logR.index[-1]
  
     cobalt_ratio_pcf_probes_logR.to_csv("${tumor}.cobalt.ratio.pcf", sep='\\t', index=False)
-    """
+    """.stripIndent()
 }
 
 process runPurple {

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,10 @@ profiles {
             container = 'papaemmelab/purple:v0.1.0'
         }
     }
+
+    test {
+        process.memory = "4 GB"
+    }
 }
 
 // Executor properties

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,7 +48,7 @@ profiles {
         }
         process {
             executor = 'local'
-            container = 'papaemmelab/purple:v0.1.0'
+            container = 'papaemmelab/purple:v0.1.1'
         }
     }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,10 +51,6 @@ profiles {
             container = 'papaemmelab/purple:v0.1.0'
         }
     }
-
-    test {
-        process.memory = "4 GB"
-    }
 }
 
 // Executor properties

--- a/nf-test.config
+++ b/nf-test.config
@@ -5,8 +5,4 @@ config {
     configFile "tests/nextflow.config"
     profile "cloud"
 
-    params {
-        memory = '4 GB'
-    }
-
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -3,6 +3,10 @@ config {
     testsDir "tests"
     workDir ".nf-test"
     configFile "tests/nextflow.config"
-    profile "cloud,test"
+    profile "cloud"
+
+    params {
+        memory = '4 GB'
+    }
 
 }

--- a/nf-test.config
+++ b/nf-test.config
@@ -3,6 +3,6 @@ config {
     testsDir "tests"
     workDir ".nf-test"
     configFile "tests/nextflow.config"
-    profile "cloud"
+    profile "cloud,test"
 
 }

--- a/tests/data/TEST.cobalt.ratio.pcf
+++ b/tests/data/TEST.cobalt.ratio.pcf
@@ -1,0 +1,3 @@
+sampleID	chrom	arm	start.pos	end.pos	n.probes	mean
+S1	2	p	14001	397001	340	-7.24
+S1	17	p	1	397001	341	-8.813389396729216

--- a/tests/main.bincobalt.nf.test
+++ b/tests/main.bincobalt.nf.test
@@ -1,0 +1,41 @@
+nextflow_process {
+
+    name "Test Process binCobalt"
+    script "main.nf"
+    process "binCobalt"
+
+    test("Should bin Cobalt without failures") {
+
+        when {
+            params {
+                tumor = "TEST"
+                binProbes = 100
+                binLogR = 0.5
+                cobalt_ratio_pcf = "${projectDir}/tests/outdir/cobalt/TEST.cobalt.ratio.pcf"
+                cobalt_ratio_tsv = "${projectDir}/tests/outdir/cobalt/TEST.cobalt.ratio.tsv.gz"
+            }
+            process {
+                """
+                input[0] = Channel.value(params.tumor)
+                input[1] = Channel.value(params.binProbes)
+                input[2] = Channel.value(params.binLogR)
+                input[3] = Channel.fromPath(params.cobalt_ratio_pcf)
+                input[4] = Channel.fromPath(params.cobalt_ratio_tsv)
+                """
+            }
+        }
+
+        then {
+            assert process.success
+            assert snapshot(process.out).match()
+            
+            // check expected files
+            with(process.out) {
+                assert cobalt_ratio_tsv.size() == 1
+                assert cobalt_ratio_pcf.size() == 1
+            }
+        }
+
+    }
+
+}

--- a/tests/main.bincobalt.nf.test
+++ b/tests/main.bincobalt.nf.test
@@ -11,8 +11,8 @@ nextflow_process {
                 tumor = "TEST"
                 binProbes = 100
                 binLogR = 0.5
-                cobalt_ratio_pcf = "${projectDir}/tests/outdir/cobalt/TEST.cobalt.ratio.pcf"
-                cobalt_ratio_tsv = "${projectDir}/tests/outdir/cobalt/TEST.cobalt.ratio.tsv.gz"
+                cobalt_ratio_pcf = "${projectDir}/tests/data/TEST.cobalt.ratio.pcf"
+                cobalt_ratio_tsv = "${projectDir}/tests/data/TEST.cobalt.ratio.tsv.gz"
             }
             process {
                 """

--- a/tests/main.bincobalt.nf.test.snap
+++ b/tests/main.bincobalt.nf.test.snap
@@ -1,0 +1,25 @@
+{
+    "Should bin Cobalt without failures": {
+        "content": [
+            {
+                "0": [
+                    "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
+                ],
+                "1": [
+                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
+                ],
+                "cobalt_ratio_pcf": [
+                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
+                ],
+                "cobalt_ratio_tsv": [
+                    "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T11:15:21.745138"
+    }
+}

--- a/tests/main.nf.test
+++ b/tests/main.nf.test
@@ -16,8 +16,8 @@ nextflow_pipeline {
             with(workflow) {
                 assert failed
                 assert exitStatus == 1
-                assert trace.tasks().size() == 3
-                assert workflow.trace.succeeded().size() == 2
+                assert trace.tasks().size() == 4
+                assert workflow.trace.succeeded().size() == 3
                 assert workflow.trace.failed().size() == 1
             }
         }

--- a/tests/main.runcobalt.nf.test.snap
+++ b/tests/main.runcobalt.nf.test.snap
@@ -6,10 +6,10 @@
                     "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
                 ],
                 "1": [
-                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
+                    "TEST.cobalt.ratio.pcf:md5,7fa4142d0d102e1f3b633d61d154d9c0"
                 ],
                 "cobalt_ratio_pcf": [
-                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
+                    "TEST.cobalt.ratio.pcf:md5,7fa4142d0d102e1f3b633d61d154d9c0"
                 ],
                 "cobalt_ratio_tsv": [
                     "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
@@ -20,6 +20,6 @@
             "nf-test": "0.9.0",
             "nextflow": "24.04.4"
         },
-        "timestamp": "2024-08-07T14:27:19.908802"
+        "timestamp": "2024-08-07T14:43:04.879169"
     }
 }

--- a/tests/main.runcobalt.nf.test.snap
+++ b/tests/main.runcobalt.nf.test.snap
@@ -6,16 +6,20 @@
                     "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
                 ],
                 "1": [
-                    "TEST.cobalt.ratio.pcf:md5,7fa4142d0d102e1f3b633d61d154d9c0"
+                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
                 ],
                 "cobalt_ratio_pcf": [
-                    "TEST.cobalt.ratio.pcf:md5,7fa4142d0d102e1f3b633d61d154d9c0"
+                    "TEST.cobalt.ratio.pcf:md5,cd95f6b56cecfd80461bf1bd13c7a9fd"
                 ],
                 "cobalt_ratio_tsv": [
                     "TEST.cobalt.ratio.tsv.gz:md5,87cf8451b04e4373fc4dd7ccda3e6afe"
                 ]
             }
         ],
-        "timestamp": "2024-01-23T10:50:58.292541"
+        "meta": {
+            "nf-test": "0.9.0",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:27:19.908802"
     }
 }

--- a/tests/main.runpurple.nf.test
+++ b/tests/main.runpurple.nf.test
@@ -40,6 +40,7 @@ nextflow_process {
                 input[0] = Channel.value(params.tumor)
                 input[1] = runAmber.out
                 input[2] = runCobalt.out
+                input[3] = "${params.outdir}/cobalt"
                 """
             }
         }


### PR DESCRIPTION
Several modifications in order to improve workflow for routine use.
- Added binning in order to decrease oversegmentation by grouping together combinations of probes with similar logR values.
- Added option to specify min/max purity and regenerate purple solution.
- Added check to not rerun amber/cobalt if results previously generated.